### PR TITLE
Add support multiple alerts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='zabbixcli',
-      version = '1.0.4',
+      version = '1.0.5',
       description = 'Tool for manage zabbix templates as YAML files.',
       author = 'Alexey Dubkov',
       author_email = 'alexey.dubkov@gmail.com',

--- a/zabbixlib/cli.py
+++ b/zabbixlib/cli.py
@@ -278,9 +278,9 @@ class ZabbixCLI(ZabbixCLIArguments):
             ZabbixAutoreg(self.zapi, self.template).apply()
 
     def _apply_trigger_action(self):
-        alert = self.template.get('alert')
-        if alert:
-            ZabbixTriggerAction(self.zapi, self.template, self.config, self.template_id).apply()
+        alerts = self.template.get('alerts', [])
+        for alert in alerts:
+            ZabbixTriggerAction(self.zapi, alert, self.config, self.template_id, self.template_name).apply()
 
     def _apply_discovery(self, discovery):
         ZabbixDiscovery(self.zapi, discovery, self.config, self.template_id).apply()


### PR DESCRIPTION
This add support multiple alerts configuration:

Example:

``` yaml
name: "Template Policy"
groups:
  - "Templates"

alerts:
    -
        name: "Email for policy-team"
        severity: "Warning"
        do:
            -
                to_user: "policy-team"
                over: "Email"
    -
        name: "Page for policy-team"
        severity: "High"
        subject: trigger
        text: |
            name:{TRIGGER.NAME}
            status:{TRIGGER.STATUS}
            value:{ITEM.VALUE1}
            hostname:{HOSTNAME}
            ip:{IPADDRESS}
            id:{TRIGGER.ID}
            event_id:{EVENT.ID}
            severity:{TRIGGER.SEVERITY}
        recovery: True
        recovery_subject: "resolve"
        recovery_text: |
            name:{TRIGGER.NAME}
            status:{TRIGGER.STATUS}
            value:{ITEM.VALUE1}
            hostname:{HOSTNAME}
            ip:{IPADDRESS}
            id:{TRIGGER.ID}
            event_id:{EVENT.ID}
            severity:{TRIGGER.SEVERITY}
        do:
            -
                to_user: "policy-team"
                over: "PagerDuty"

applications:

  "Policy":

    - name:         "Policy service running"
      key:          "proc.num[,,,policy]"
      method:       "Active"
      description:  |
                    Monitor if Policy service running or not.

triggers:

  -
    name:           "Policy service is not running on {HOST.NAME}"
    warn_level:     "High"
    expression:     "{Template Policy:proc.num[,,,policy].max(#3)}=0"
```
